### PR TITLE
Add delegate support for task submission

### DIFF
--- a/source/guillotine/executor.d
+++ b/source/guillotine/executor.d
@@ -7,7 +7,8 @@ import guillotine.future : Future;
 import guillotine.value;
 import guillotine.result : Result;
 import guillotine.provider;
-import std.traits : isFunction, FunctionTypeOf, ReturnType, arity;
+import std.traits : isFunction, isDelegate, FunctionTypeOf, ReturnType, arity;
+import std.functional : toDelegate;
 
 // TODO: Document
 private bool isSupportedReturn(alias FuncSymbol)()
@@ -44,7 +45,7 @@ private class FutureTask : Task
     /** 
      * Function to call
      */
-    private Value function() func;
+    private Value delegate() func;
 
     /** 
      * Constructs a new `FutureTask` with the
@@ -54,7 +55,7 @@ private class FutureTask : Task
      *   future = the `Future` to associate with
      *   func = the function to run
      */
-    this(Future future, Value function() func)
+    this(Future future, Value delegate() func)
     {
         this.future = future;
         this.func = func;
@@ -217,15 +218,15 @@ public class Executor
      * Returns: the task's `Future`
      */
     public Future submitTask(alias Symbol)()
-    if (isFunction!(Symbol) && isSupportedFunction!(Symbol))
+    if ((isFunction!(Symbol) || isDelegate!(Symbol)) && isSupportedFunction!(Symbol))
     {
         FutureTask task;
 
-        Value function() ptr;
+        Value delegate() ptr;
         alias func = Symbol;
-        
 
-        ptr = &WorkerFunction!(func).workerFunc;
+
+        ptr = toDelegate(&WorkerFunction!(func).workerFunc);
 
         version(unittest)
         {

--- a/source/guillotine/executor.d
+++ b/source/guillotine/executor.d
@@ -225,8 +225,14 @@ public class Executor
         Value delegate() ptr;
         alias func = Symbol;
 
-
-        ptr = toDelegate(&WorkerFunction!(func).workerFunc);
+        static if(isDelegate!(Symbol))
+        {
+            ptr = &WorkerFunction!(func).workerFunc;
+        }
+        else
+        {
+            ptr = toDelegate(&WorkerFunction!(func).workerFunc);
+        }
 
         version(unittest)
         {


### PR DESCRIPTION
## Purpose

- Added support for delegates
- We now secretly convert everything to a delegate (if a function, otherwise assign directly)

## Todo :writing_hand: 

- [x] Unit tests
- [x] Implementation
    - [x] Move to `Value delegate()` type
    - [x] Check for `isFunction` and `isDelegate`
    - [x] Only convert if `isFunction` is true